### PR TITLE
Using bundled gems instead of global gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+  gem 'cocoapods-keys'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RubyInline (3.12.5)
+      ZenTest (~> 4.3)
+    ZenTest (4.12.0)
+    cocoapods-keys (2.1.0)
+      dotenv
+      osx_keychain
+    dotenv (2.7.5)
+    osx_keychain (1.0.2)
+      RubyInline (~> 3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods-keys!
+
+BUNDLED WITH
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following steps should be all that's necessary to build Nio with Xcode.
 ```bash
 $ git clone https://github.com/kiliankoe/nio.git
 $ cd nio
-$ gem install cocoapods-keys
+$ bundle install
 $ pod install
 $ xed .
 ```


### PR DESCRIPTION
Using a gemfile is better than requiring "gem install" because "gem install" on system ruby without ruby manager installs it globally. 
The gemfile allows to install required gems locally for the project.