### PR TITLE
Make placeholder avatars purple

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		392389892386FD3900B2E1DF /* MXClient+Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392389882386FD3900B2E1DF /* MXClient+Publisher.swift */; };
 		3923898D238859D100B2E1DF /* MX+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3923898C238859D100B2E1DF /* MX+Identifiable.swift */; };
 		3923898F2388707E00B2E1DF /* RoomListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3923898E2388707E00B2E1DF /* RoomListItemView.swift */; };
-		39238991238870FE00B2E1DF /* Color+random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39238990238870FE00B2E1DF /* Color+random.swift */; };
 		392389942388899200B2E1DF /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392389932388899200B2E1DF /* Formatter.swift */; };
 		392389982388998F00B2E1DF /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392389972388998F00B2E1DF /* ActivityIndicator.swift */; };
 		3923899A2388A52A00B2E1DF /* MatrixServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392389992388A52A00B2E1DF /* MatrixServices.swift */; };
@@ -69,7 +68,6 @@
 		392389882386FD3900B2E1DF /* MXClient+Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXClient+Publisher.swift"; sourceTree = "<group>"; };
 		3923898C238859D100B2E1DF /* MX+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MX+Identifiable.swift"; sourceTree = "<group>"; };
 		3923898E2388707E00B2E1DF /* RoomListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListItemView.swift; sourceTree = "<group>"; };
-		39238990238870FE00B2E1DF /* Color+random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+random.swift"; sourceTree = "<group>"; };
 		392389932388899200B2E1DF /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		392389972388998F00B2E1DF /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		392389992388A52A00B2E1DF /* MatrixServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixServices.swift; sourceTree = "<group>"; };
@@ -267,7 +265,6 @@
 				39D166C52385C804006DD257 /* String+Emoji.swift */,
 				392389882386FD3900B2E1DF /* MXClient+Publisher.swift */,
 				3923898C238859D100B2E1DF /* MX+Identifiable.swift */,
-				39238990238870FE00B2E1DF /* Color+random.swift */,
 				393411C823904428003B49B8 /* MXEvent.swift */,
 				3902B89F239410EE00698B87 /* ContentSizeCategory.swift */,
 			);
@@ -531,7 +528,6 @@
 				39D166C62385C804006DD257 /* String+Emoji.swift in Sources */,
 				392389D4238F3E8F00B2E1DF /* NIORecentRooms.swift in Sources */,
 				3902B89C2393FE6100698B87 /* MessageView.swift in Sources */,
-				39238991238870FE00B2E1DF /* Color+random.swift in Sources */,
 				39C93209238553E4004449E1 /* RoomView.swift in Sources */,
 				392389CC238EBB1500B2E1DF /* ReverseList.swift in Sources */,
 				392389942388899200B2E1DF /* Formatter.swift in Sources */,

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -29,10 +29,21 @@ struct RoomListItemView: View {
     var rightDetail: String
     var badge: UInt
 
+    var gradient: LinearGradient {
+        let tintColor: Color = .purple
+        let colors = [
+            tintColor.opacity(0.75),
+            tintColor
+        ]
+        return LinearGradient(gradient: Gradient(colors: colors),
+                       startPoint: .top,
+                       endPoint: .bottom)
+    }
+
     var image: some View {
         ZStack {
             Circle()
-                .foregroundColor(.purple)
+                .fill(gradient)
             Text(title.prefix(2).uppercased())
                 .font(.system(.headline, design: .rounded))
                 .foregroundColor(.white)

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -34,7 +34,7 @@ struct RoomListItemView: View {
             Circle()
                 .foregroundColor(.purple)
             Text(title.prefix(2).uppercased())
-                .font(.headline)
+                .font(.system(.headline, design: .rounded))
                 .foregroundColor(.white)
         }
         .frame(width: 40, height: 40)

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -32,10 +32,10 @@ struct RoomListItemView: View {
     var image: some View {
         ZStack {
             Circle()
-                .foregroundColor(.random)
+                .foregroundColor(.purple)
             Text(title.prefix(2).uppercased())
                 .font(.headline)
-                .foregroundColor(.random)
+                .foregroundColor(.white)
         }
         .frame(width: 40, height: 40)
         .accessibility(addTraits: .isImage)

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -45,6 +45,7 @@ struct RoomListItemView: View {
             Circle()
                 .fill(gradient)
             Text(title.prefix(2).uppercased())
+                .multilineTextAlignment(.center)
                 .font(.system(.headline, design: .rounded))
                 .foregroundColor(.white)
         }

--- a/Nio/Extensions/Color+random.swift
+++ b/Nio/Extensions/Color+random.swift
@@ -1,9 +1,0 @@
-import SwiftUI
-
-extension Color {
-    static var random: Color {
-        Color(red: .random(in: 0...1),
-              green: .random(in: 0...1),
-              blue: .random(in: 0...1))
-    }
-}


### PR DESCRIPTION
The current implementation assigns distinct fore/background colors to each room that that …

1. are chosen at random (lots of 💩 colors)

2. are non-persistent (poor recognizability)

3. have poor accessibility (lots of poor contrasts)

Assigning each room a distinguishable color provides the nice benefit of being able to easily recognize it by its color (or avatar image, if available), not just by reading its name.

I'd argue however that the current approach does not actually fulfill this task:

1. By using randomization contacts that are dear to your heart might be assigned an unchangeable undesirable brown color. Additionally two adjacently listed rooms might be assigned indistinguishable colors thanks to randomness.

2. The colors change on every app launch, which basically defeats any intent of improving recognizability of individual rooms.

3. Often times the randomized color combinations for fore- & background color actually make the text illegible.

---

## Option A: De-randomize the colors

One approach for guaranteeing maximally distinguishable colors is to [sample from a golden ratio distribution](https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/).

For this however one would have to map the user's rooms to a `Range<Int>`.
While this could be achieved by means of an "auto-increment" (à la SQL) identifier assigned to each rooms during the initial instantiation, persisted across app launches, it would have a major drawback: the colors will deteriorate over time, especially for people who frequently create/join and delete/leave rooms, as removed rooms would leave gaps in the color range mapping, leading to progressively worse color separation. (This, too, could be avoided by keeping a "free"-list of such colors and draining that list before incrementing the counter. But by that time one will have inadvertently re-invented a naïve sort of garbage-collection. Ooops. 🤷‍♂ )

All in all a randomized/sampled approach seems to be highly complex to get right, for rather limited benefit.

---

## Option B: Embrace the purple

Apple's Messages actually just uses a uniform color for its placeholder avatars: gray.

I'd like to propose this:

1. Replace the randomized colors with a uniform color.

2. Add a subtle gradient to make the avatars pop a bit more.

3. Make the avatar's text uniformly white.

4. Change the text's font to "SF-Compact Rounded" (like in Messages)

![Artboard](https://user-images.githubusercontent.com/138017/70398142-bd8ea180-1a18-11ea-8d99-7be0bf336875.png)

---

(This PR implements "Option B".)