### PR TITLE
Data-layer logic for visual event grouping

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		A329A2AF0574896611D82CC1 /* Pods_NioTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FF7D25C200D0F7228279B72 /* Pods_NioTests.framework */; };
 		CAC46D6B23A55E940079C24F /* PeekableIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6A23A55E930079C24F /* PeekableIterator.swift */; };
 		CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */; };
+		CAC46D6F23A56BBE0079C24F /* GroupingIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */; };
+		CAC46D7123A56BFB0079C24F /* GroupingIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -101,6 +103,8 @@
 		7FF7D25C200D0F7228279B72 /* Pods_NioTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NioTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAC46D6A23A55E930079C24F /* PeekableIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeekableIterator.swift; sourceTree = "<group>"; };
 		CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekableIteratorTests.swift; sourceTree = "<group>"; };
+		CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupingIterator.swift; sourceTree = "<group>"; };
+		CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupingIteratorTests.swift; sourceTree = "<group>"; };
 		E2D5B8AFEEB28F750CE393D1 /* Pods-NioTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NioTests.debug.xcconfig"; path = "Target Support Files/Pods-NioTests/Pods-NioTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -159,6 +163,7 @@
 				392389932388899200B2E1DF /* Formatter.swift */,
 				392389972388998F00B2E1DF /* ActivityIndicator.swift */,
 				CAC46D6A23A55E930079C24F /* PeekableIterator.swift */,
+				CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -187,6 +192,7 @@
 			children = (
 				393411D0239087D2003B49B8 /* EventCollectionTests.swift */,
 				CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */,
+				CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */,
 				393411D2239087D2003B49B8 /* Info.plist */,
 			);
 			path = NioTests;
@@ -513,6 +519,7 @@
 			files = (
 				CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */,
 				393411D1239087D2003B49B8 /* EventCollectionTests.swift in Sources */,
+				CAC46D7123A56BFB0079C24F /* GroupingIteratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -528,6 +535,7 @@
 				393411C923904428003B49B8 /* MXEvent.swift in Sources */,
 				3923898D238859D100B2E1DF /* MX+Identifiable.swift in Sources */,
 				39C932072384BB13004449E1 /* RecentRoomsView.swift in Sources */,
+				CAC46D6F23A56BBE0079C24F /* GroupingIterator.swift in Sources */,
 				3923899A2388A52A00B2E1DF /* MatrixServices.swift in Sources */,
 				393411C723903C94003B49B8 /* EventCollection.swift in Sources */,
 				3902B8A52395A77800698B87 /* LoadingView.swift in Sources */,

--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -47,7 +47,9 @@
 		CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */; };
 		CAC46D6F23A56BBE0079C24F /* GroupingIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */; };
 		CAC46D7123A56BFB0079C24F /* GroupingIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */; };
+		CAC46D7323A6AE890079C24F /* TypedEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7223A6AE890079C24F /* TypedEvents.swift */; };
 		CAC46D7723A6CB6C0079C24F /* MXEventType+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7623A6CB6C0079C24F /* MXEventType+Equatable.swift */; };
+		CAC46D7923A6D4B90079C24F /* TypedEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7823A6D4B90079C24F /* TypedEventsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,7 +108,9 @@
 		CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekableIteratorTests.swift; sourceTree = "<group>"; };
 		CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupingIterator.swift; sourceTree = "<group>"; };
 		CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupingIteratorTests.swift; sourceTree = "<group>"; };
+		CAC46D7223A6AE890079C24F /* TypedEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedEvents.swift; sourceTree = "<group>"; };
 		CAC46D7623A6CB6C0079C24F /* MXEventType+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXEventType+Equatable.swift"; sourceTree = "<group>"; };
+		CAC46D7823A6D4B90079C24F /* TypedEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedEventsTests.swift; sourceTree = "<group>"; };
 		E2D5B8AFEEB28F750CE393D1 /* Pods-NioTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NioTests.debug.xcconfig"; path = "Target Support Files/Pods-NioTests/Pods-NioTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -166,6 +170,7 @@
 				392389972388998F00B2E1DF /* ActivityIndicator.swift */,
 				CAC46D6A23A55E930079C24F /* PeekableIterator.swift */,
 				CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */,
+				CAC46D7223A6AE890079C24F /* TypedEvents.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -195,6 +200,7 @@
 				393411D0239087D2003B49B8 /* EventCollectionTests.swift */,
 				CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */,
 				CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */,
+				CAC46D7823A6D4B90079C24F /* TypedEventsTests.swift */,
 				393411D2239087D2003B49B8 /* Info.plist */,
 			);
 			path = NioTests;
@@ -521,6 +527,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */,
+				CAC46D7923A6D4B90079C24F /* TypedEventsTests.swift in Sources */,
 				393411D1239087D2003B49B8 /* EventCollectionTests.swift in Sources */,
 				CAC46D7123A56BFB0079C24F /* GroupingIteratorTests.swift in Sources */,
 			);
@@ -559,6 +566,7 @@
 				3902B89E2393FE8200698B87 /* GenericEventView.swift in Sources */,
 				392389982388998F00B2E1DF /* ActivityIndicator.swift in Sources */,
 				39C931FE23847E7F004449E1 /* MatrixStore.swift in Sources */,
+				CAC46D7323A6AE890079C24F /* TypedEvents.swift in Sources */,
 				39C931E12384328A004449E1 /* RootView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */; };
 		CAC46D6F23A56BBE0079C24F /* GroupingIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */; };
 		CAC46D7123A56BFB0079C24F /* GroupingIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */; };
+		CAC46D7723A6CB6C0079C24F /* MXEventType+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D7623A6CB6C0079C24F /* MXEventType+Equatable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +106,7 @@
 		CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekableIteratorTests.swift; sourceTree = "<group>"; };
 		CAC46D6E23A56BBE0079C24F /* GroupingIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupingIterator.swift; sourceTree = "<group>"; };
 		CAC46D7023A56BFB0079C24F /* GroupingIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupingIteratorTests.swift; sourceTree = "<group>"; };
+		CAC46D7623A6CB6C0079C24F /* MXEventType+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXEventType+Equatable.swift"; sourceTree = "<group>"; };
 		E2D5B8AFEEB28F750CE393D1 /* Pods-NioTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NioTests.debug.xcconfig"; path = "Target Support Files/Pods-NioTests/Pods-NioTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -279,6 +281,7 @@
 				3923898C238859D100B2E1DF /* MX+Identifiable.swift */,
 				393411C823904428003B49B8 /* MXEvent.swift */,
 				3902B89F239410EE00698B87 /* ContentSizeCategory.swift */,
+				CAC46D7623A6CB6C0079C24F /* MXEventType+Equatable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -537,6 +540,7 @@
 				39C932072384BB13004449E1 /* RecentRoomsView.swift in Sources */,
 				CAC46D6F23A56BBE0079C24F /* GroupingIterator.swift in Sources */,
 				3923899A2388A52A00B2E1DF /* MatrixServices.swift in Sources */,
+				CAC46D7723A6CB6C0079C24F /* MXEventType+Equatable.swift in Sources */,
 				393411C723903C94003B49B8 /* EventCollection.swift in Sources */,
 				3902B8A52395A77800698B87 /* LoadingView.swift in Sources */,
 				3902B8A0239410EE00698B87 /* ContentSizeCategory.swift in Sources */,

--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		39D166C82385C832006DD257 /* EventContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D166C72385C832006DD257 /* EventContainerView.swift */; };
 		87FE3870173FD55A91B15921 /* Pods_Nio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3410F361E5A713D19ECEF861 /* Pods_Nio.framework */; };
 		A329A2AF0574896611D82CC1 /* Pods_NioTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FF7D25C200D0F7228279B72 /* Pods_NioTests.framework */; };
+		CAC46D6B23A55E940079C24F /* PeekableIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6A23A55E930079C24F /* PeekableIterator.swift */; };
+		CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +99,8 @@
 		39D166C52385C804006DD257 /* String+Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
 		39D166C72385C832006DD257 /* EventContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventContainerView.swift; sourceTree = "<group>"; };
 		7FF7D25C200D0F7228279B72 /* Pods_NioTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NioTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAC46D6A23A55E930079C24F /* PeekableIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeekableIterator.swift; sourceTree = "<group>"; };
+		CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeekableIteratorTests.swift; sourceTree = "<group>"; };
 		E2D5B8AFEEB28F750CE393D1 /* Pods-NioTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NioTests.debug.xcconfig"; path = "Target Support Files/Pods-NioTests/Pods-NioTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -154,6 +158,7 @@
 			children = (
 				392389932388899200B2E1DF /* Formatter.swift */,
 				392389972388998F00B2E1DF /* ActivityIndicator.swift */,
+				CAC46D6A23A55E930079C24F /* PeekableIterator.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -181,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				393411D0239087D2003B49B8 /* EventCollectionTests.swift */,
+				CAC46D6C23A55EBA0079C24F /* PeekableIteratorTests.swift */,
 				393411D2239087D2003B49B8 /* Info.plist */,
 			);
 			path = NioTests;
@@ -505,6 +511,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAC46D6D23A55EBA0079C24F /* PeekableIteratorTests.swift in Sources */,
 				393411D1239087D2003B49B8 /* EventCollectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -533,6 +540,7 @@
 				392389942388899200B2E1DF /* Formatter.swift in Sources */,
 				392389D6238F3EB200B2E1DF /* NIORoomSummary.swift in Sources */,
 				39D166C82385C832006DD257 /* EventContainerView.swift in Sources */,
+				CAC46D6B23A55E940079C24F /* PeekableIterator.swift in Sources */,
 				39C931DF2384328A004449E1 /* SceneDelegate.swift in Sources */,
 				3902B8A32395935600698B87 /* SettingsView.swift in Sources */,
 				39C931F523846966004449E1 /* LoginView.swift in Sources */,

--- a/Nio/Extensions/MXEventType+Equatable.swift
+++ b/Nio/Extensions/MXEventType+Equatable.swift
@@ -1,0 +1,57 @@
+//
+//  MXEventType+Equatable.swift
+//  Nio
+//
+//  Created by Vincent Esche on 12/15/19.
+//  Copyright © 2019 Kilian Koeltzsch. All rights reserved.
+//
+
+import Foundation
+import SwiftMatrixSDK
+
+// TODO: Remove, once
+// https://github.com/matrix-org/matrix-ios-sdk/pull/755
+// has been merged or the lack of `Equatable` been resolved upstream.
+extension MXEventType: Equatable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public static func == (lhs: MXEventType, rhs: MXEventType) -> Bool {
+        switch (lhs, rhs) {
+        case (.roomName, .roomName): return true
+        case (.roomTopic, .roomTopic): return true
+        case (.roomAvatar, .roomAvatar): return true
+        case (.roomMember, .roomMember): return true
+        case (.roomCreate, .roomCreate): return true
+        case (.roomJoinRules, .roomJoinRules): return true
+        case (.roomPowerLevels, .roomPowerLevels): return true
+        case (.roomAliases, .roomAliases): return true
+        case (.roomCanonicalAlias, .roomCanonicalAlias): return true
+        case (.roomEncrypted, .roomEncrypted): return true
+        case (.roomEncryption, .roomEncryption): return true
+        case (.roomGuestAccess, .roomGuestAccess): return true
+        case (.roomHistoryVisibility, .roomHistoryVisibility): return true
+        case (.roomKey, .roomKey): return true
+        case (.roomForwardedKey, .roomForwardedKey): return true
+        case (.roomKeyRequest, .roomKeyRequest): return true
+        case (.roomMessage, .roomMessage): return true
+        case (.roomMessageFeedback, .roomMessageFeedback): return true
+        case (.roomRedaction, .roomRedaction): return true
+        case (.roomThirdPartyInvite, .roomThirdPartyInvite): return true
+        case (.roomTag, .roomTag): return true
+        case (.presence, .presence): return true
+        case (.typing, .typing): return true
+        case (.callInvite, .callInvite): return true
+        case (.callCandidates, .callCandidates): return true
+        case (.callAnswer, .callAnswer): return true
+        case (.callHangup, .callHangup): return true
+        case (.reaction, .reaction): return true
+        case (.receipt, .receipt): return true
+        case (.roomTombStone, .roomTombStone): return true
+        case (.keyVerificationStart, .keyVerificationStart): return true
+        case (.keyVerificationAccept, .keyVerificationAccept): return true
+        case (.keyVerificationKey, .keyVerificationKey): return true
+        case (.keyVerificationMac, .keyVerificationMac): return true
+        case (.keyVerificationCancel, .keyVerificationCancel): return true
+        default: return false
+        }
+    }
+}

--- a/Nio/Utility/GroupedEvents.swift
+++ b/Nio/Utility/GroupedEvents.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftMatrixSDK
+
+struct GroupBounds: OptionSet, Equatable, Hashable {
+    let rawValue: Int
+
+    static let before: Self = .init(rawValue: 1 << 0)
+    static let after: Self = .init(rawValue: 1 << 1)
+
+    static let both: Self = [.before, .after]
+}
+
+struct Bounded<Wrapped> {
+    var wrapped: Wrapped
+    var bounds: GroupBounds
+
+    init(_ wrapped: Wrapped, bounds: GroupBounds) {
+        self.wrapped = wrapped
+        self.bounds = bounds
+    }
+}
+
+extension Bounded: Equatable where Wrapped: Equatable {}
+
+extension Bounded: Hashable where Wrapped: Hashable {}
+
+extension Bounded: Identifiable where Wrapped: Identifiable {
+    // swiftlint:disable:next type_name
+    typealias ID = Wrapped.ID
+
+    var id: ID {
+        wrapped.id
+    }
+}
+
+extension Bounded where Wrapped == MXEvent {
+    var event: MXEvent {
+        get { wrapped }
+        set { wrapped = newValue }
+    }
+}
+
+struct EventGroup {
+    let events: [MXEvent]
+
+    init(_ events: [MXEvent] = []) {
+        self.events = events
+    }
+}
+
+struct EventGroups {
+    var groups: [EventGroup]
+
+    init(_ events: [MXEvent]) {
+        self.groups = Self.groups(from: events)
+    }
+
+    // Collects events in groups of equal `.sender`:
+    static func groups<S>(from events: S) -> [EventGroup] where S: Sequence, S.Element == MXEvent {
+        let iterator = events.makeIterator()
+        let groupingIterator = GroupingIterator(iterator) { $0.sender }
+        return IteratorSequence(groupingIterator).map { EventGroup($0) }
+    }
+}

--- a/Nio/Utility/GroupingIterator.swift
+++ b/Nio/Utility/GroupingIterator.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// An iterator with a grouping closure that returns sub-sequences next element
+/// without removing it without advancing the iterator.
+struct GroupingIterator<Iterator>: IteratorProtocol where Iterator: IteratorProtocol {
+    typealias Element = [Iterator.Element]
+    typealias Closure = (Iterator.Element, Iterator.Element) -> Bool
+
+    private var iterator: PeekableIterator<Iterator>
+    private let closure: Closure
+
+    /// Creates an grouping iterator, wrapping `iterator`.
+    /// - Parameters:
+    ///   - iterator: the wrapped iterator
+    ///   - closure: A predicate that returns true if its second argument
+    ///              should be added to the same group as the first argument;
+    ///              otherwise, false.
+    init(_ iterator: Iterator, by closure: @escaping Closure) {
+        self.iterator = .init(iterator)
+        self.closure = closure
+    }
+
+    mutating func next() -> Element? {
+        guard var previous = iterator.next() else {
+            return nil
+        }
+
+        var group: [Iterator.Element] = [previous]
+
+        while let peek = iterator.peek() {
+            guard closure(previous, peek) else {
+                break
+            }
+
+            // The forced unwrap is safe here, due to having peeked above:
+            let element = iterator.next()!
+
+            group.append(element)
+
+            previous = element
+        }
+
+        return group
+    }
+}

--- a/Nio/Utility/PeekableIterator.swift
+++ b/Nio/Utility/PeekableIterator.swift
@@ -1,15 +1,20 @@
 import Foundation
 
+/// An iterator with a `peek()` that returns the next element
+/// without removing it without advancing the iterator.
 struct PeekableIterator<Iterator>: IteratorProtocol where Iterator: IteratorProtocol {
     typealias Element = Iterator.Element
 
     private var iterator: Iterator
     private var peeked: Element?
 
+    /// Creates a peekable iterator, wrapping `iterator`.
+    /// - Parameter iterator: the wrapped iterator
     init(_ iterator: Iterator) {
         self.iterator = iterator
     }
 
+    /// Advances the iterator and returns the next value.
     mutating func next() -> Element? {
         guard let peeked = peeked else {
             return iterator.next()
@@ -18,6 +23,7 @@ struct PeekableIterator<Iterator>: IteratorProtocol where Iterator: IteratorProt
         return peeked
     }
 
+    /// Returns the `next()` value without advancing the iterator.
     mutating func peek() -> Element? {
         if peeked == nil {
             peeked = iterator.next()

--- a/Nio/Utility/PeekableIterator.swift
+++ b/Nio/Utility/PeekableIterator.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct PeekableIterator<Iterator>: IteratorProtocol where Iterator: IteratorProtocol {
+    typealias Element = Iterator.Element
+
+    private var iterator: Iterator
+    private var peeked: Element?
+
+    init(_ iterator: Iterator) {
+        self.iterator = iterator
+    }
+
+    mutating func next() -> Element? {
+        guard let peeked = peeked else {
+            return iterator.next()
+        }
+        defer { self.peeked = nil }
+        return peeked
+    }
+
+    mutating func peek() -> Element? {
+        if peeked == nil {
+            peeked = iterator.next()
+        }
+        return peeked
+    }
+}

--- a/Nio/Utility/TypedEvents.swift
+++ b/Nio/Utility/TypedEvents.swift
@@ -1,0 +1,120 @@
+import Foundation
+import SwiftMatrixSDK
+
+protocol TypeableEvent {
+    var type: String { get }
+    var sender: String { get }
+}
+
+/// An event and its type
+struct TypedEvent<Event> where Event: TypeableEvent {
+    let type: MXEventType
+    let event: Event
+}
+
+extension TypedEvent: Equatable where Event: Equatable {
+    static func == (lhs: TypedEvent, rhs: TypedEvent) -> Bool {
+        guard lhs.type == rhs.type else {
+            return false
+        }
+
+        guard lhs.event == rhs.event else {
+            return false
+        }
+
+        return true
+    }
+}
+
+/// A non-empty group of homogeneous events
+struct TypedEventGroup<Event> where Event: TypeableEvent {
+    let type: MXEventType
+    let events: [Event]
+
+    init(type: MXEventType, events: [TypedEvent<Event>]) {
+        let events = events.map { $0.event }
+        self.init(type: type, events: events)
+    }
+
+    init(type: MXEventType, events: [Event]) {
+        assert(!events.isEmpty)
+        assert(events.allSatisfy { event in
+            MXEventType(identifier: event.type) == type
+        })
+
+        self.type = type
+        self.events = events
+    }
+}
+
+extension TypedEventGroup: Equatable where Event: Equatable {
+    static func == (lhs: TypedEventGroup, rhs: TypedEventGroup) -> Bool {
+        lhs.events == rhs.events
+    }
+}
+
+/// A collection of groups of events of equal type.
+struct TypedEventGroups<Event>: Collection where Event: TypeableEvent {
+    typealias Index = Int
+
+    var startIndex: Int {
+        0
+    }
+
+    var endIndex: Int {
+        groups.count
+    }
+
+    let groups: [TypedEventGroup<Event>]
+
+    init<S>(events: S) where S: Sequence, S.Element == Event {
+        self.init(groups: Self.grouped(events: events))
+    }
+
+    init(groups: [TypedEventGroup<Event>]) {
+        self.groups = groups
+    }
+
+    private static func grouped<S>(events: S) -> [TypedEventGroup<Event>] where S: Sequence, S.Element == Event {
+        let typedEvents: LazyMapSequence<S, TypedEvent<Event>> = events.lazy.map { event in
+            let type = MXEventType(identifier: event.type)
+            return TypedEvent(type: type, event: event)
+        }
+        let iterator = typedEvents.makeIterator()
+        let groupingIterator = GroupingIterator(iterator) { lhs, rhs in
+            // Split the events into groups of consecutive events of same type:
+            guard lhs.type == rhs.type else {
+                return false
+            }
+            switch lhs.type {
+            // Perform additional specialized grouping for message events:
+            case .roomMessage, .roomMessageFeedback:
+                // Groups into consecutive events of same sender:
+                return lhs.event.sender == rhs.event.sender
+            case _:
+                return true
+            }
+        }
+        let groups = IteratorSequence(groupingIterator)
+        return groups.compactMap { events in
+            guard let event = events.first else {
+                return nil
+            }
+            return TypedEventGroup(type: event.type, events: events)
+        }
+    }
+
+    subscript(position: Int) -> TypedEventGroup<Event> {
+        groups[position]
+    }
+
+    func index(after index: Int) -> Int {
+        index + 1
+    }
+}
+
+extension TypedEventGroups: Equatable where Event: Equatable {
+    static func == (lhs: TypedEventGroups, rhs: TypedEventGroups) -> Bool {
+        lhs.groups == rhs.groups
+    }
+}

--- a/NioTests/GroupingIteratorTests.swift
+++ b/NioTests/GroupingIteratorTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import Nio
+
+class GroupingIteratorTests: XCTestCase {
+    func testGroupingIteratorShouldSplitElementsByClosure() {
+        let elements: [Int] = [0, 1, 3, 2, 3]
+        let iterator = elements.makeIterator()
+        let groupingIterator: GroupingIterator = .init(iterator) {
+            // Group elements by their even/odd-ness:
+            ($0 % 2) == ($1 % 2)
+        }
+
+        let expected: [[Int]] = [
+            [0],
+            [1, 3],
+            [2],
+            [3]
+        ]
+        let actual = Array(IteratorSequence(groupingIterator))
+        XCTAssertEqual(actual, expected)
+    }
+}

--- a/NioTests/PeekableIteratorTests.swift
+++ b/NioTests/PeekableIteratorTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import Nio
+
+class PeekableIteratorTests: XCTestCase {
+    func testNextShouldRemoveAndReturnNextElement() {
+        let elements = [0, 1, 2, 3, 4]
+        let iterator = elements.makeIterator()
+        var peekableIterator = PeekableIterator(iterator)
+
+        let actual0 = peekableIterator.next()
+        let expected0 = 0
+        XCTAssertEqual(actual0, expected0)
+
+        let actual1 = peekableIterator.next()
+        let expected1 = 1
+        XCTAssertEqual(actual1, expected1)
+    }
+
+    func testPeekShouldReturnButNotRemoveNextElement() {
+        let elements = [0, 1, 2, 3, 4]
+        let iterator = elements.makeIterator()
+        var peekableIterator = PeekableIterator(iterator)
+
+        // Calling peek should return the next element:
+        let actual0 = peekableIterator.peek()
+        let expected0 = 0
+        XCTAssertEqual(actual0, expected0)
+
+        // Calling peek again should return the same element:
+        let actual1 = peekableIterator.peek()
+        let expected1 = 0
+        XCTAssertEqual(actual1, expected1)
+    }
+
+    func testNextAfterPeekShouldRemoveAndReturnPeekedElement() {
+        let elements = [0, 1, 2, 3, 4]
+        let iterator = elements.makeIterator()
+        var peekableIterator = PeekableIterator(iterator)
+
+        // Calling peek should return the next element:
+        let actual0 = peekableIterator.peek()
+        let expected0 = 0
+        XCTAssertEqual(actual0, expected0)
+
+        // Calling next should return the peeked element:
+        let actual1 = peekableIterator.next()
+        let expected1 = 0
+        XCTAssertEqual(actual1, expected1)
+    }
+
+    func testPeekAfterNextShouldRemoveAndReturnPeekedElement() {
+        let elements = [0, 1, 2, 3, 4]
+        let iterator = elements.makeIterator()
+        var peekableIterator = PeekableIterator(iterator)
+
+        // Calling next should return the next element:
+        let actual0 = peekableIterator.next()
+        let expected0 = 0
+        XCTAssertEqual(actual0, expected0)
+
+        // Calling peek should return the next element:
+        let actual1 = peekableIterator.peek()
+        let expected1 = 1
+        XCTAssertEqual(actual1, expected1)
+    }
+}

--- a/NioTests/TypedEventsTests.swift
+++ b/NioTests/TypedEventsTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import SwiftMatrixSDK
+
+@testable import Nio
+
+class TypedEventsTests: XCTestCase {
+    struct Event: TypeableEvent, Equatable {
+        let id: Int
+        let type: String
+        let sender: String
+
+        public init(id: Int, type: MXEventType, sender: String) {
+            self.id = id
+            self.type = type.identifier
+            self.sender = sender
+        }
+    }
+
+    func testGroupHomogeneousMessages() {
+        let events: [Event] = [
+            Event(id: 0, type: .roomMessage, sender: "Alice"),
+            Event(id: 1, type: .roomMessage, sender: "Alice"),
+            Event(id: 2, type: .roomMessage, sender: "Bob"),
+            Event(id: 3, type: .roomMessage, sender: "Eve"),
+            Event(id: 4, type: .roomMessage, sender: "Eve"),
+            Event(id: 5, type: .roomMessage, sender: "Bob")
+        ]
+
+        let actual = TypedEventGroups(events: events)
+        let expected: TypedEventGroups<Event> = TypedEventGroups(groups: [
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 0, type: .roomMessage, sender: "Alice"),
+                Event(id: 1, type: .roomMessage, sender: "Alice")
+            ]),
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 2, type: .roomMessage, sender: "Bob")
+            ]),
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 3, type: .roomMessage, sender: "Eve"),
+                Event(id: 4, type: .roomMessage, sender: "Eve")
+            ]),
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 5, type: .roomMessage, sender: "Bob")
+            ])
+        ])
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testGroupHeterogeneousEvents() {
+        let events: [Event] = [
+            Event(id: 0, type: .roomMessage, sender: "Alice"),
+            Event(id: 1, type: .roomMessage, sender: "Alice"),
+            Event(id: 2, type: .presence, sender: "Alice"),
+            Event(id: 3, type: .roomMessage, sender: "Eve"),
+            Event(id: 4, type: .roomMessage, sender: "Eve"),
+            Event(id: 5, type: .roomMessage, sender: "Bob")
+        ]
+
+        let actual = TypedEventGroups(events: events)
+        let expected: TypedEventGroups<Event> = TypedEventGroups(groups: [
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 0, type: .roomMessage, sender: "Alice"),
+                Event(id: 1, type: .roomMessage, sender: "Alice")
+            ]),
+            TypedEventGroup(type: .presence, events: [
+                Event(id: 2, type: .presence, sender: "Alice")
+            ]),
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 3, type: .roomMessage, sender: "Eve"),
+                Event(id: 4, type: .roomMessage, sender: "Eve")
+            ]),
+            TypedEventGroup(type: .roomMessage, events: [
+                Event(id: 5, type: .roomMessage, sender: "Bob")
+            ])
+        ])
+
+        XCTAssertEqual(actual, expected)
+    }
+}


### PR DESCRIPTION
This PR adds basic logic for collecting a room's events into groups, that can then be visualized in a compact fashion.

Partially resolves https://github.com/kiliankoe/nio/issues/22.