### PR TITLE
Reactions

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		3902B8A32395935600698B87 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3902B8A22395935600698B87 /* SettingsView.swift */; };
 		3902B8A52395A77800698B87 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3902B8A42395A77800698B87 /* LoadingView.swift */; };
 		3922219624366989004D8794 /* EventContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3922219524366989004D8794 /* EventContextMenu.swift */; };
+		39222199243689D6004D8794 /* ReactionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39222198243689D6004D8794 /* ReactionEvent.swift */; };
+		3922219D24368B25004D8794 /* CustomEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3922219C24368B25004D8794 /* CustomEvent.swift */; };
+		392221A02437285B004D8794 /* ReactionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3922219F2437285B004D8794 /* ReactionPicker.swift */; };
 		392389892386FD3900B2E1DF /* MXClient+Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392389882386FD3900B2E1DF /* MXClient+Publisher.swift */; };
 		3923898D238859D100B2E1DF /* MX+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3923898C238859D100B2E1DF /* MX+Identifiable.swift */; };
 		3923898F2388707E00B2E1DF /* RoomListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3923898E2388707E00B2E1DF /* RoomListItemView.swift */; };
@@ -84,6 +87,9 @@
 		3902B8A22395935600698B87 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		3902B8A42395A77800698B87 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		3922219524366989004D8794 /* EventContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventContextMenu.swift; sourceTree = "<group>"; };
+		39222198243689D6004D8794 /* ReactionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionEvent.swift; sourceTree = "<group>"; };
+		3922219C24368B25004D8794 /* CustomEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEvent.swift; sourceTree = "<group>"; };
+		3922219F2437285B004D8794 /* ReactionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionPicker.swift; sourceTree = "<group>"; };
 		392389882386FD3900B2E1DF /* MXClient+Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MXClient+Publisher.swift"; sourceTree = "<group>"; };
 		3923898C238859D100B2E1DF /* MX+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MX+Identifiable.swift"; sourceTree = "<group>"; };
 		3923898E2388707E00B2E1DF /* RoomListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListItemView.swift; sourceTree = "<group>"; };
@@ -186,6 +192,24 @@
 			path = "Event Views";
 			sourceTree = "<group>";
 		};
+		39222197243689CB004D8794 /* Custom Events */ = {
+			isa = PBXGroup;
+			children = (
+				39222198243689D6004D8794 /* ReactionEvent.swift */,
+				3922219C24368B25004D8794 /* CustomEvent.swift */,
+			);
+			path = "Custom Events";
+			sourceTree = "<group>";
+		};
+		3922219E24372834004D8794 /* ContextMenu */ = {
+			isa = PBXGroup;
+			children = (
+				3922219524366989004D8794 /* EventContextMenu.swift */,
+				3922219F2437285B004D8794 /* ReactionPicker.swift */,
+			);
+			path = ContextMenu;
+			sourceTree = "<group>";
+		};
 		392389922388898800B2E1DF /* Utility */ = {
 			isa = PBXGroup;
 			children = (
@@ -210,6 +234,7 @@
 		392389D0238F2E6200B2E1DF /* Matrix Wrapper */ = {
 			isa = PBXGroup;
 			children = (
+				39222197243689CB004D8794 /* Custom Events */,
 				392389D1238F2E6F00B2E1DF /* NIORoom.swift */,
 				392389D5238F3EB200B2E1DF /* NIORoomSummary.swift */,
 				393411C623903C94003B49B8 /* EventCollection.swift */,
@@ -296,7 +321,7 @@
 				39C932062384BB13004449E1 /* RecentRoomsView.swift */,
 				3923898E2388707E00B2E1DF /* RoomListItemView.swift */,
 				39C93208238553E4004449E1 /* RoomView.swift */,
-				3922219524366989004D8794 /* EventContextMenu.swift */,
+				3922219E24372834004D8794 /* ContextMenu */,
 				39C9320A23856033004449E1 /* MessageComposerView.swift */,
 				3907AB482393FE0E00B25DE9 /* Event Views */,
 			);
@@ -605,6 +630,7 @@
 				3902B8A52395A77800698B87 /* LoadingView.swift in Sources */,
 				3902B8A0239410EE00698B87 /* ContentSizeCategory.swift in Sources */,
 				39D166C62385C804006DD257 /* String+Emoji.swift in Sources */,
+				392221A02437285B004D8794 /* ReactionPicker.swift in Sources */,
 				3902B89C2393FE6100698B87 /* MessageView.swift in Sources */,
 				CAC46D5723A272D10079C24F /* BorderlessMessageView.swift in Sources */,
 				39C93209238553E4004449E1 /* RoomView.swift in Sources */,
@@ -612,6 +638,7 @@
 				392389942388899200B2E1DF /* Formatter.swift in Sources */,
 				39BA0723240B3C9A00FD28C6 /* MXCredentials+Keychain.swift in Sources */,
 				CAC46D6323A278F40079C24F /* PreviewProvider+Enumeration.swift in Sources */,
+				39222199243689D6004D8794 /* ReactionEvent.swift in Sources */,
 				392389D6238F3EB200B2E1DF /* NIORoomSummary.swift in Sources */,
 				39BA0725240B4E8D00FD28C6 /* AppSettings.swift in Sources */,
 				39D166C82385C832006DD257 /* EventContainerView.swift in Sources */,
@@ -619,6 +646,7 @@
 				CAC46D5823A272D10079C24F /* MessageViewModel.swift in Sources */,
 				39C931DF2384328A004449E1 /* SceneDelegate.swift in Sources */,
 				3902B8A32395935600698B87 /* SettingsView.swift in Sources */,
+				3922219D24368B25004D8794 /* CustomEvent.swift in Sources */,
 				3922219624366989004D8794 /* EventContextMenu.swift in Sources */,
 				39C931F523846966004449E1 /* LoginView.swift in Sources */,
 				39BA0727240B534600FD28C6 /* Color+allAccent.swift in Sources */,

--- a/Nio/Conversations/ContextMenu/EventContextMenu.swift
+++ b/Nio/Conversations/ContextMenu/EventContextMenu.swift
@@ -26,10 +26,10 @@ private struct EventContextMenuViewModel {
             kMXEventTypeStringRoomMessage
         ]
 
-//        if reactableEvents.contains(event.type) {
-//            canReact = true
+        if reactableEvents.contains(event.type) {
+            canReact = true
 //            canReply = true
-//        }
+        }
 
         if event.sender == userId && reactableEvents.contains(event.type) {
 //            canEdit = true

--- a/Nio/Conversations/ContextMenu/ReactionPicker.swift
+++ b/Nio/Conversations/ContextMenu/ReactionPicker.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ReactionPicker: View {
+    let emoji = ["👍", "👎", "😄", "🎉", "❤️", "🚀", "👀"]
+
+    var picked: (String) -> Void
+
+    var body: some View {
+        HStack {
+            ForEach(emoji, id: \.self) { emoji in
+                Button(action: { self.picked(emoji) },
+                       label: { Text(emoji) })
+            }
+        }
+    }
+}
+
+struct ReactionPicker_Previews: PreviewProvider {
+    static var previews: some View {
+        ReactionPicker(picked: { _ in })
+    }
+}

--- a/Nio/Conversations/ContextMenu/ReactionPicker.swift
+++ b/Nio/Conversations/ContextMenu/ReactionPicker.swift
@@ -6,10 +6,19 @@ struct ReactionPicker: View {
     var picked: (String) -> Void
 
     var body: some View {
-        HStack {
-            ForEach(emoji, id: \.self) { emoji in
-                Button(action: { self.picked(emoji) },
-                       label: { Text(emoji) })
+        VStack {
+            Text("Tap on an emoji to send that reaction.")
+                .foregroundColor(.gray)
+                .font(.headline)
+                .padding(.bottom, 30)
+            HStack(spacing: 10) {
+                ForEach(emoji, id: \.self) { emoji in
+                    Button(action: { self.picked(emoji) },
+                           label: {
+                        Text(emoji)
+                            .font(.largeTitle)
+                    })
+                }
             }
         }
     }

--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -3,6 +3,7 @@ import SwiftMatrixSDK
 
 struct EventContainerView: View {
     var event: MXEvent
+    var reactions: [String]
     var connectedEdges: ConnectedEdges
     var showSender: Bool
 
@@ -23,10 +24,11 @@ struct EventContainerView: View {
                     GenericEventView(text: "🗑 Redacted because of: \(reason)")
                 )
             }
-            
+
             // FIXME: remove
             // swiftlint:disable:next force_try
             let messageModel = try! MessageViewModel(event: event,
+                                                     reactions: reactions,
                                                      showSender: showSender)
             return AnyView(
                 MessageView(

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -79,19 +79,45 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         .foregroundColor(textColor).opacity(0.5)
     }
 
+    var reactionsView: some View {
+        HStack(spacing: 3) {
+            ForEach(model.groupedReactions, id: \.0) { (emoji, count) in
+                    HStack(spacing: 1) {
+                        Text(emoji)
+                            .font(.caption)
+                        Text(String(count))
+                            .foregroundColor(self.textColor)
+                            .font(.callout)
+                    }
+                    .padding(.vertical, 2)
+                    .padding(.horizontal, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(self.gradient)
+                            .shadow(radius: 1)
+                    )
+            }
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             senderView
-            VStack(alignment: isMe ? .trailing : .leading, spacing: 5) {
-                bodyView
-                if !connectedEdges.contains(.bottomEdge) {
-                    // It's the last message in a group, so show a timestamp:
-                    timestampView
+            ZStack(alignment: isMe ? .bottomTrailing : .bottomLeading) {
+                VStack(alignment: isMe ? .trailing : .leading, spacing: 5) {
+                    bodyView
+                    if !connectedEdges.contains(.bottomEdge) {
+                        // It's the last message in a group, so show a timestamp:
+                        timestampView
+                    }
                 }
+                .padding(10)
+                .background(background)
+
+                reactionsView.offset(x: 5, y: 15)
             }
-            .padding(10)
-            .background(background)
         }
+        .padding(.bottom, model.reactions.isEmpty ? 0 : 15)
     }
 }
 
@@ -100,18 +126,25 @@ struct BorderedMessageView_Previews: PreviewProvider {
         var id: String
         var text: String
         var sender: String
-        var timestamp: String
         var showSender: Bool
+        var timestamp: String
+        var reactions: [String]
     }
 
-    static func lone(sender: String, userId: String, showSender: Bool) -> some View {
+    static func lone(sender: String,
+                     text: String = "Lorem ipsum dolor sit amet!",
+                     userId: String,
+                     showSender: Bool,
+                     reactions: [String]
+    ) -> some View {
         BorderedMessageView(
             model: MessageViewModel(
                 id: "0",
-                text: "Lorem ipsum dolor sit amet!",
+                text: text,
                 sender: sender,
+                showSender: showSender,
                 timestamp: "12:29",
-                showSender: showSender
+                reactions: reactions
             ),
             connectedEdges: []
         )
@@ -119,7 +152,11 @@ struct BorderedMessageView_Previews: PreviewProvider {
             .environment(\.userId, userId)
     }
 
-    static func grouped(sender: String, userId: String, showSender: Bool) -> some View {
+    static func grouped(sender: String,
+                        userId: String,
+                        showSender: Bool,
+                        reactions: [String]
+    ) -> some View {
         let alignment: HorizontalAlignment = (sender == userId) ? .trailing : .leading
 
         return VStack(alignment: alignment, spacing: 3) {
@@ -128,8 +165,9 @@ struct BorderedMessageView_Previews: PreviewProvider {
                     id: "0",
                     text: "This is a message",
                     sender: sender,
+                    showSender: showSender,
                     timestamp: "12:29",
-                    showSender: showSender
+                    reactions: reactions
                 ),
                 connectedEdges: [.bottomEdge]
             )
@@ -138,8 +176,9 @@ struct BorderedMessageView_Previews: PreviewProvider {
                     id: "0",
                     text: "that's quickly followed",
                     sender: sender,
+                    showSender: showSender,
                     timestamp: "12:29",
-                    showSender: showSender
+                    reactions: reactions
                 ),
                 connectedEdges: [.topEdge, .bottomEdge]
             )
@@ -148,8 +187,9 @@ struct BorderedMessageView_Previews: PreviewProvider {
                     id: "0",
                     text: "by some more messages.",
                     sender: sender,
+                    showSender: showSender,
                     timestamp: "12:29",
-                    showSender: showSender
+                    reactions: reactions
                 ),
                 connectedEdges: [.topEdge]
             )
@@ -161,23 +201,39 @@ struct BorderedMessageView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             enumeratingColorSchemes {
-                lone(sender: "John Doe", userId: "Jane Doe", showSender: false)
+                lone(sender: "John Doe",
+                     text: "Lorem",
+                     userId: "Jane Doe",
+                     showSender: false,
+                     reactions: ["💜", "💜", "👍", "🥳"])
             }
             .previewDisplayName("Incoming Lone Messages")
 
             enumeratingColorSchemes {
-                lone(sender: "Jane Doe", userId: "Jane Doe", showSender: false)
+                lone(sender: "Jane Doe",
+                     userId: "Jane Doe",
+                     showSender: false,
+                     reactions: ["❤️", "❤️", "👍", "🥳"])
             }
             .previewDisplayName("Outgoing Lone Messages")
 
-            grouped(sender: "John Doe", userId: "Jane Doe", showSender: true)
+            grouped(sender: "John Doe",
+                    userId: "Jane Doe",
+                    showSender: true,
+                    reactions: ["❤️", "❤️", "👍", "🥳"])
             .previewDisplayName("Incoming Grouped Messages")
 
-            grouped(sender: "Jane Doe", userId: "Jane Doe", showSender: false)
+            grouped(sender: "Jane Doe",
+                    userId: "Jane Doe",
+                    showSender: false,
+                    reactions: [])
             .previewDisplayName("Outgoing Grouped Messages")
 
             enumeratingSizeCategories {
-                lone(sender: "John Doe", userId: "Jane Doe", showSender: false)
+                lone(sender: "John Doe",
+                     userId: "Jane Doe",
+                     showSender: false,
+                     reactions: ["🚀"])
             }
             .previewDisplayName("Incoming Messages")
         }

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -80,22 +80,30 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
     }
 
     var reactionsView: some View {
-        HStack(spacing: 3) {
-            ForEach(model.groupedReactions, id: \.0) { (emoji, count) in
-                    HStack(spacing: 1) {
-                        Text(emoji)
-                            .font(.caption)
-                        Text(String(count))
-                            .foregroundColor(self.textColor)
-                            .font(.callout)
+        // The conditional EmptyView here exists since SwiftUI apparently decides
+        // to give space to the HStack even if it's empty, which looks awkward.
+        Group {
+            if model.reactions.isEmpty {
+                EmptyView()
+            } else {
+                HStack(spacing: 3) {
+                    ForEach(model.groupedReactions, id: \.0) { (emoji, count) in
+                        HStack(spacing: 1) {
+                            Text(emoji)
+                                .font(.caption)
+                            Text(String(count))
+                                .foregroundColor(self.textColor)
+                                .font(.callout)
+                        }
+                        .padding(.vertical, 2)
+                        .padding(.horizontal, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(self.gradient)
+                                .shadow(radius: 1)
+                        )
                     }
-                    .padding(.vertical, 2)
-                    .padding(.horizontal, 6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 20)
-                            .fill(self.gradient)
-                            .shadow(radius: 1)
-                    )
+                }
             }
         }
     }
@@ -103,7 +111,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             senderView
-            ZStack(alignment: isMe ? .bottomTrailing : .bottomLeading) {
+            VStack(alignment: isMe ? .trailing : .leading, spacing: 3) {
                 VStack(alignment: isMe ? .trailing : .leading, spacing: 5) {
                     bodyView
                     if !connectedEdges.contains(.bottomEdge) {
@@ -114,10 +122,9 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
                 .padding(10)
                 .background(background)
 
-                reactionsView.offset(x: 5, y: 15)
+                reactionsView
             }
         }
-        .padding(.bottom, model.reactions.isEmpty ? 0 : 15)
     }
 }
 

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -82,18 +82,24 @@ struct BorderlessMessageView_Previews: PreviewProvider {
         var id: String
         var text: String
         var sender: String
-        var timestamp: String
         var showSender: Bool
+        var timestamp: String
+        var reactions: [String]
     }
 
-    static func lone(sender: String, userId: String, showSender: Bool) -> some View {
+    static func lone(sender: String,
+                     userId: String,
+                     showSender: Bool,
+                     reactions: [String]
+    ) -> some View {
         BorderlessMessageView(
             model: MessageViewModel(
                 id: "0",
                 text: "🐧",
                 sender: sender,
+                showSender: showSender,
                 timestamp: "12:29",
-                showSender: showSender
+                reactions: reactions
             ),
             connectedEdges: []
         )
@@ -101,7 +107,11 @@ struct BorderlessMessageView_Previews: PreviewProvider {
             .environment(\.userId, userId)
     }
 
-    static func grouped(sender: String, userId: String, showSender: Bool) -> some View {
+    static func grouped(sender: String,
+                        userId: String,
+                        showSender: Bool,
+                        reactions: [String]
+    ) -> some View {
         let alignment: HorizontalAlignment = (sender == userId) ? .trailing : .leading
 
         return VStack(alignment: alignment, spacing: 3) {
@@ -110,8 +120,9 @@ struct BorderlessMessageView_Previews: PreviewProvider {
                     id: "0",
                     text: "🐶",
                     sender: sender,
+                    showSender: showSender,
                     timestamp: "12:29",
-                    showSender: showSender
+                    reactions: reactions
                 ),
                 connectedEdges: [.bottomEdge]
             )
@@ -120,8 +131,9 @@ struct BorderlessMessageView_Previews: PreviewProvider {
                     id: "0",
                     text: "🦊",
                     sender: sender,
+                    showSender: showSender,
                     timestamp: "12:29",
-                    showSender: showSender
+                    reactions: reactions
                 ),
                 connectedEdges: [.topEdge, .bottomEdge]
             )
@@ -130,8 +142,9 @@ struct BorderlessMessageView_Previews: PreviewProvider {
                     id: "0",
                     text: "🐻",
                     sender: sender,
+                    showSender: showSender,
                     timestamp: "12:29",
-                    showSender: showSender
+                    reactions: reactions
                 ),
                 connectedEdges: [.topEdge]
             )
@@ -143,23 +156,38 @@ struct BorderlessMessageView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             enumeratingColorSchemes {
-                lone(sender: "John Doe", userId: "Jane Doe", showSender: false)
+                lone(sender: "John Doe",
+                     userId: "Jane Doe",
+                     showSender: false,
+                     reactions: [])
             }
             .previewDisplayName("Incoming Lone Messages")
 
             enumeratingColorSchemes {
-                lone(sender: "Jane Doe", userId: "Jane Doe", showSender: false)
+                lone(sender: "Jane Doe",
+                     userId: "Jane Doe",
+                     showSender: false,
+                     reactions: [])
             }
             .previewDisplayName("Outgoing Lone Messages")
 
-            grouped(sender: "John Doe", userId: "Jane Doe", showSender: true)
+            grouped(sender: "John Doe",
+                    userId: "Jane Doe",
+                    showSender: true,
+                    reactions: [])
             .previewDisplayName("Incoming Grouped Messages")
 
-            grouped(sender: "Jane Doe", userId: "Jane Doe", showSender: false)
+            grouped(sender: "Jane Doe",
+                    userId: "Jane Doe",
+                    showSender: false,
+                    reactions: [])
             .previewDisplayName("Outgoing Grouped Messages")
 
             enumeratingSizeCategories {
-                lone(sender: "John Doe", userId: "Jane Doe", showSender: false)
+                lone(sender: "John Doe",
+                     userId: "Jane Doe",
+                     showSender: false,
+                     reactions: [])
             }
             .previewDisplayName("Incoming Messages")
         }

--- a/Nio/Conversations/Event Views/MessageView/MessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageView.swift
@@ -54,18 +54,25 @@ struct MessageView_Previews: PreviewProvider {
         var id: String
         var text: String
         var sender: String
-        var timestamp: String
         var showSender: Bool
+        var timestamp: String
+        var reactions: [String]
     }
 
-    static func message(text: String, sender: String, userId: String, showSender: Bool) -> some View {
+    static func message(text: String,
+                        sender: String,
+                        userId: String,
+                        showSender: Bool,
+                        reactions: [String]
+    ) -> some View {
         MessageView(
             model: .constant(MessageViewModel(
                 id: "0",
                 text: text,
                 sender: sender,
+                showSender: showSender,
                 timestamp: "12:29",
-                showSender: showSender
+                reactions: reactions
             )),
             connectedEdges: []
         )
@@ -79,14 +86,16 @@ struct MessageView_Previews: PreviewProvider {
                 text: "Hi there!",
                 sender: "John Doe",
                 userId: "Jane Doe",
-                showSender: true
+                showSender: true,
+                reactions: []
             )
 
             message(
                 text: "👋",
                 sender: "John Doe",
                 userId: "Jane Doe",
-                showSender: false
+                showSender: false,
+                reactions: []
             )
         }
         .accentColor(.purple)

--- a/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
@@ -17,7 +17,7 @@ extension MessageViewModelProtocol {
     var groupedReactions: [(String, Int)] {
         reactions
             .reduce(into: [:]) { counts, reaction in counts[reaction, default: 0] += 1 }
-            .sorted { $0.1 < $1.1 }
+            .sorted { $0.1 > $1.1 }
     }
 }
 

--- a/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
@@ -4,13 +4,22 @@ protocol MessageViewModelProtocol {
     var id: String { get }
     var text: String { get }
     var sender: String { get }
-    var timestamp: String { get }
     var showSender: Bool { get }
+    var timestamp: String { get }
+    var reactions: [String] { get }
 }
 
 extension MessageViewModelProtocol {
     var isEmoji: Bool {
         (text.count <= 3) && text.containsOnlyEmoji
+    }
+
+    var groupedReactions: [(String, Int)] {
+        var counts: [String: Int] = [:]
+        for reaction in reactions {
+            counts[reaction, default: 0] += 1
+        }
+        return counts.sorted { $0.1 < $1.1 }
     }
 }
 
@@ -40,19 +49,22 @@ struct MessageViewModel: MessageViewModelProtocol {
         event.sender
     }
 
+    var showSender: Bool
+
     var timestamp: String {
         Formatter.string(for: event.timestamp, timeStyle: .short)
     }
 
-    var showSender: Bool
+    var reactions: [String]
 
     private let event: MXEvent
 
-    public init(event: MXEvent, showSender: Bool) throws {
+    public init(event: MXEvent, reactions: [String], showSender: Bool) throws {
         try Self.validate(event: event)
 
         self.event = event
         self.showSender = showSender
+        self.reactions = reactions
     }
 
     private static func validate(event: MXEvent) throws {

--- a/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
@@ -15,11 +15,9 @@ extension MessageViewModelProtocol {
     }
 
     var groupedReactions: [(String, Int)] {
-        var counts: [String: Int] = [:]
-        for reaction in reactions {
-            counts[reaction, default: 0] += 1
-        }
-        return counts.sorted { $0.1 < $1.1 }
+        reactions
+            .reduce(into: [:]) { counts, reaction in counts[reaction, default: 0] += 1 }
+            .sorted { $0.1 < $1.1 }
     }
 }
 

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -59,8 +59,9 @@ struct RoomView: View {
 
     var body: some View {
         VStack {
-            ReverseList(events.wrapped) { event in
+            ReverseList(events.renderableEvents) { event in
                 EventContainerView(event: event,
+                                   reactions: self.events.reactions(for: event),
                                    connectedEdges: self.events.connectedEdges(of: event),
                                    showSender: !self.isDirect)
                     .padding(.horizontal)

--- a/Nio/Matrix Wrapper/Custom Events/CustomEvent.swift
+++ b/Nio/Matrix Wrapper/Custom Events/CustomEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol CustomEvent {
+    func encodeContent() throws -> [String: Any]
+}

--- a/Nio/Matrix Wrapper/Custom Events/ReactionEvent.swift
+++ b/Nio/Matrix Wrapper/Custom Events/ReactionEvent.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftMatrixSDK
+
+struct ReactionEvent {
+    let eventId: String
+    let key: String
+    let relType = "m.annotation"
+}
+
+extension ReactionEvent: CustomEvent {
+    func encodeContent() throws -> [String: Any] {
+        [
+            "m.relates_to": [
+                "event_id": eventId,
+                "key": key,
+                "rel_type": relType
+            ]
+        ]
+    }
+}

--- a/Nio/Matrix Wrapper/EventCollection.swift
+++ b/Nio/Matrix Wrapper/EventCollection.swift
@@ -4,6 +4,15 @@ import SwiftMatrixSDK
 struct EventCollection {
     var wrapped: [MXEvent]
 
+    var renderableEvents: [MXEvent] {
+        let renderableEventTypes = [
+            kMXEventTypeStringRoomMessage,
+            kMXEventTypeStringRoomMember,
+            kMXEventTypeStringRoomTopic
+        ]
+        return wrapped.filter { renderableEventTypes.contains($0.type) }
+    }
+
     init(_ events: [MXEvent]) {
         self.wrapped = events
     }
@@ -44,6 +53,17 @@ struct EventCollection {
         }
 
         fatalError("Non-covered position case? \(sender) \(preSender) \(sucSender)")
+    }
+
+    func relatedEvents(of event: MXEvent) -> [MXEvent] {
+        wrapped.filter { $0.relatesTo?.eventId == event.eventId }
+    }
+
+    // FIXME: For the love of god...
+    func reactions(for event: MXEvent) -> [String] {
+        relatedEvents(of: event)
+            .filter { $0.type == kMXEventTypeStringReaction }
+            .compactMap { ($0.content["m.relates_to"] as? [String: Any])?["key"] as? String }
     }
 }
 

--- a/Nio/Matrix Wrapper/NIORoom.swift
+++ b/Nio/Matrix Wrapper/NIORoom.swift
@@ -3,12 +3,6 @@ import Combine
 import SwiftMatrixSDK
 
 class NIORoom: ObservableObject {
-    static var displayedMessageTypes = [
-        kMXEventTypeStringRoomMessage,
-        kMXEventTypeStringRoomMember,
-        kMXEventTypeStringRoomTopic
-    ]
-
     private var room: MXRoom
 
     @Published var summary: NIORoomSummary
@@ -21,13 +15,11 @@ class NIORoom: ObservableObject {
         let currentBatch = enumerator?.nextEventsBatch(200) ?? []
         print("Got \(currentBatch.count) events.")
 
-        let filteredEvents = currentBatch.filter { Self.displayedMessageTypes.contains($0.type) }
-        self.eventCache.append(contentsOf: filteredEvents)
+        self.eventCache.append(contentsOf: currentBatch)
     }
 
     func add(event: MXEvent, direction: MXTimelineDirection, roomState: MXRoomState?) {
         print("New event of type: \(event.type!)")
-        guard Self.displayedMessageTypes.contains(event.type ?? "") else { return }
 
         switch direction {
         case .backwards:

--- a/Nio/Matrix Wrapper/NIORoom.swift
+++ b/Nio/Matrix Wrapper/NIORoom.swift
@@ -71,6 +71,17 @@ class NIORoom: ObservableObject {
         self.objectWillChange.send()
     }
 
+    func react(toEventId eventId: String, emoji: String) {
+        // swiftlint:disable:next force_try
+        let content = try! ReactionEvent(eventId: eventId, key: emoji).encodeContent()
+        //swiftlint:disable:next redundant_optional_initialization
+        var localEcho: MXEvent? = nil
+        room.sendEvent(.reaction, content: content, localEcho: &localEcho) { response in
+            print(response)
+            self.objectWillChange.send()
+        }
+    }
+
     func redact(eventId: String, reason: String?) {
         room.redactEvent(eventId, reason: reason) { response in
             self.objectWillChange.send()


### PR DESCRIPTION
<img width="545" alt="Screen Shot 2020-04-04 at 01 51 16" src="https://user-images.githubusercontent.com/2625584/78413243-d39f1e00-7616-11ea-8289-27fa02933acf.png">

<img width="545" alt="Screen Shot 2020-04-04 at 01 51 57" src="https://user-images.githubusercontent.com/2625584/78413261-efa2bf80-7616-11ea-9f05-52986d162d98.png">

<img width="545" alt="Screen Shot 2020-04-04 at 01 49 40" src="https://user-images.githubusercontent.com/2625584/78413183-98045400-7616-11ea-9c9d-d544f7a9b3b3.png">

Basic reaction handling 🎉 

There's still quite a few todos for future enhancements:
- The emoji picker only shows those few hardcoded emoji for now.
- Visible reactions on a message can not be interacted with
  - So no sending of existing reactions by tapping
  - And no unsending of reactions...
- No accessible info on reactions (who sent what)

Oh and 🤞 for Apple announcing *anything* related to reversed lists for SwiftUI at WWDC in June so that all of that can just disappear here and events won't be flipped in the context menu 🙈 