### PR TITLE
Improved look for edited messages

### DIFF
--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -6,6 +6,7 @@ struct EventContainerView: View {
     var reactions: [Reaction]
     var connectedEdges: ConnectedEdges
     var showSender: Bool
+    var edits: [MXEvent]
     var contextMenuModel: EventContextMenuModel
 
     private var topPadding: CGFloat {
@@ -25,6 +26,27 @@ struct EventContainerView: View {
                 return AnyView(
                     RedactionEventView(model: .init(sender: event.sender, redactor: redactor, reason: reason))
                 )
+            }
+
+            guard !event.contentHasBeenEdited() else {
+                print("EDITED")
+                let messageModel = try! MessageViewModel(event: edits.last ?? event,
+                                                         reactions: reactions,
+                                                         showSender: showSender)
+                return AnyView(
+                    MessageView(
+                        model: .constant(messageModel),
+                        contextMenuModel: contextMenuModel,
+                        connectedEdges: connectedEdges,
+                        isEdited: true
+                    )
+                    .padding(.top, topPadding)
+                    .padding(.bottom, bottomPadding)
+                )
+            }
+
+            if event.isEdit() {
+                return AnyView(EmptyView())
             }
 
             if event.isMediaAttachment() {

--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -29,7 +29,8 @@ struct EventContainerView: View {
             }
 
             guard !event.contentHasBeenEdited() else {
-                print("EDITED")
+                // FIXME: remove
+                // swiftlint:disable:next force_try
                 let messageModel = try! MessageViewModel(event: edits.last ?? event,
                                                          reactions: reactions,
                                                          showSender: showSender)

--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -28,24 +28,6 @@ struct EventContainerView: View {
                 )
             }
 
-            guard !event.contentHasBeenEdited() else {
-                // FIXME: remove
-                // swiftlint:disable:next force_try
-                let messageModel = try! MessageViewModel(event: edits.last ?? event,
-                                                         reactions: reactions,
-                                                         showSender: showSender)
-                return AnyView(
-                    MessageView(
-                        model: .constant(messageModel),
-                        contextMenuModel: contextMenuModel,
-                        connectedEdges: connectedEdges,
-                        isEdited: true
-                    )
-                    .padding(.top, topPadding)
-                    .padding(.bottom, bottomPadding)
-                )
-            }
-
             guard !event.isEdit() else {
                 return AnyView(EmptyView())
             }
@@ -56,16 +38,22 @@ struct EventContainerView: View {
                 )
             }
 
+            var newEvent = event
+            if event.contentHasBeenEdited() {
+                newEvent = edits.last ?? event
+            }
+            
             // FIXME: remove
             // swiftlint:disable:next force_try
-            let messageModel = try! MessageViewModel(event: event,
+            let messageModel = try! MessageViewModel(event: newEvent,
                                                      reactions: reactions,
                                                      showSender: showSender)
             return AnyView(
                 MessageView(
                     model: .constant(messageModel),
                     contextMenuModel: contextMenuModel,
-                    connectedEdges: connectedEdges
+                    connectedEdges: connectedEdges,
+                    isEdited: event.contentHasBeenEdited()
                 )
                 .padding(.top, topPadding)
                 .padding(.bottom, bottomPadding)

--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -46,7 +46,7 @@ struct EventContainerView: View {
                 )
             }
 
-            if event.isEdit() {
+            guard !event.isEdit() else {
                 return AnyView(EmptyView())
             }
 

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -9,6 +9,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
     var model: Model
     var contextMenuModel: EventContextMenuModel
     var connectedEdges: ConnectedEdges
+    var isEdited = false
 
     private var isMe: Bool {
         model.sender == userId
@@ -64,6 +65,17 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
             .foregroundColor(textColor)
     }
 
+    var editedBodyView: some View {
+        HStack{
+            Text(model.text)
+                .foregroundColor(textColor)
+            Text("(" + L10n.Event.edit + ")")
+                .font(.caption)
+                .foregroundColor(textColor)
+                .opacity(colorSchemeContrast == .standard ? 0.5 : 1.0)
+        }
+    }
+
     var senderView: some View {
         if model.showSender
             && !isMe
@@ -89,7 +101,11 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
             senderView
             VStack(alignment: isMe ? .trailing : .leading, spacing: 3) {
                 VStack(alignment: isMe ? .trailing : .leading, spacing: 5) {
-                    bodyView
+                    if isEdited {
+                        editedBodyView
+                    } else {
+                        bodyView
+                    }
                     if !connectedEdges.contains(.bottomEdge) {
                         // It's the last message in a group, so show a timestamp:
                         timestampView

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -66,14 +66,12 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
     }
 
     var editedBodyView: some View {
-        HStack{
-            Text(model.text)
-                .foregroundColor(textColor)
-            Text("(" + L10n.Event.edit + ")")
-                .font(.caption)
-                .foregroundColor(textColor)
-                .opacity(colorSchemeContrast == .standard ? 0.5 : 1.0)
-        }
+        Text(model.text + " ")
+            .foregroundColor(textColor)
+        + Text("(" + L10n.Event.edit + ")")
+            .font(.caption)
+            .foregroundColor(textColor
+                .opacity(colorSchemeContrast == .standard ? 0.5 : 1.0))
     }
 
     var senderView: some View {

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -46,9 +46,14 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
     }
 
     var contentEditedView: some View {
-        VStack {
-            emojiView
-            editedView
+        HStack(alignment: .bottom) {
+            if isMe {
+                editedView
+                emojiView
+            } else {
+                emojiView
+                editedView
+            }
         }
     }
 

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -2,12 +2,21 @@ import SwiftUI
 
 struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol {
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.colorSchemeContrast) var colorSchemeContrast
     @Environment(\.sizeCategory) var sizeCategory
     @Environment(\.userId) var userId
 
     var model: Model
     var contextMenuModel: EventContextMenuModel
     var connectedEdges: ConnectedEdges
+    var isEdited = false
+
+    var textColor: Color {
+        if model.sender == userId {
+            return .lightText(for: colorScheme, with: colorSchemeContrast)
+        }
+        return .primaryText(for: colorScheme, with: colorSchemeContrast)
+    }
 
     private var isMe: Bool {
         model.sender == userId
@@ -25,8 +34,22 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
         .font(.system(size: 60 * sizeCategory.scalingFactor))
     }
 
+    var editedView: some View {
+        Text("(" + L10n.Event.edit + ")")
+            .font(.caption)
+            .foregroundColor(textColor)
+            .opacity(colorSchemeContrast == .standard ? 0.5 : 1.0)
+    }
+
     var contentView: some View {
         emojiView
+    }
+
+    var contentEditedView: some View {
+        VStack {
+            emojiView
+            editedView
+        }
     }
 
     var senderView: some View {
@@ -64,7 +87,11 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
                             // It's the last message in a group, so show a timestamp:
                             timestampView
                         }
-                        contentView
+                        if isEdited {
+                            contentEditedView
+                        } else {
+                            contentView
+                        }
                     }
                     GroupedReactionsView(reactions: model.reactions)
                 }
@@ -73,7 +100,11 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
             return AnyView(
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
-                        contentView
+                        if isEdited {
+                            contentEditedView
+                        } else {
+                            contentView
+                        }
                         if !connectedEdges.contains(.bottomEdge) {
                             // It's the last message in a group, so show a timestamp:
                             timestampView

--- a/Nio/Conversations/Event Views/MessageView/MessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageView.swift
@@ -8,6 +8,7 @@ struct MessageView<Model>: View where Model: MessageViewModelProtocol {
     @Binding var model: Model
     var contextMenuModel: EventContextMenuModel
     var connectedEdges: ConnectedEdges
+    var isEdited = false
 
     private var isMe: Bool {
         model.sender == userId
@@ -18,7 +19,8 @@ struct MessageView<Model>: View where Model: MessageViewModelProtocol {
             let messageView = BorderlessMessageView(
                 model: model,
                 contextMenuModel: contextMenuModel,
-                connectedEdges: connectedEdges
+                connectedEdges: connectedEdges,
+                isEdited: self.isEdited
             )
             if isMe {
                 return AnyView(HStack {
@@ -35,7 +37,8 @@ struct MessageView<Model>: View where Model: MessageViewModelProtocol {
             let messageView = BorderedMessageView(
                 model: model,
                 contextMenuModel: contextMenuModel,
-                connectedEdges: connectedEdges
+                connectedEdges: connectedEdges,
+                isEdited: self.isEdited
             )
             if isMe {
                 return AnyView(HStack {

--- a/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
@@ -33,9 +33,16 @@ struct MessageViewModel: MessageViewModelProtocol {
     }
 
     var text: String {
-        return (event.content["body"] as? String).map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        } ?? "Error: expected string body"
+        if !event.isEdit() {
+            return (event.content["body"] as? String).map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            } ?? "Error: expected string body"
+        } else {
+            let newContent = event.content["m.new_content"]! as? NSDictionary
+            return (newContent?["body"] as? String).map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            } ?? "Error: expected string body"
+        }
     }
 
     var sender: String {

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -67,6 +67,7 @@ struct RoomView: View {
                                    reactions: self.events.reactions(for: event),
                                    connectedEdges: self.events.connectedEdges(of: event),
                                    showSender: !self.isDirect,
+                                   edits: self.events.relatedEvents(of: event),
                                    contextMenuModel: EventContextMenuModel(
                                     event: event,
                                     userId: self.userId,

--- a/Nio/Generated/Strings.swift
+++ b/Nio/Generated/Strings.swift
@@ -24,6 +24,8 @@ internal enum L10n {
   }
 
   internal enum Event {
+    /// edited
+    internal static let edit = L10n.tr("Localizable", "event.edit")
     /// Reason: %@
     internal static func reason(_ p1: String) -> String {
       return L10n.tr("Localizable", "event.reason", p1)

--- a/Nio/Matrix Wrapper/NIORoom.swift
+++ b/Nio/Matrix Wrapper/NIORoom.swift
@@ -45,8 +45,12 @@ class NIORoom: ObservableObject {
         let lastMessageEvent = eventCache.last {
             $0.type == kMXEventTypeStringRoomMessage
         }
-
-        return lastMessageEvent?.content["body"] as? String ?? ""
+        if lastMessageEvent?.isEdit() ?? false {
+            let newContent = lastMessageEvent?.content["m.new_content"]! as? NSDictionary
+            return newContent?["body"] as? String ?? ""
+        } else {
+            return lastMessageEvent?.content["body"] as? String ?? ""
+        }
     }
 
     // MARK: Sending Events

--- a/Nio/Supporting Files/en.lproj/Localizable.strings
+++ b/Nio/Supporting Files/en.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "event.redaction.redact-self" = "🗑 Messaged removed by %@";
 "event.redaction.redact-other" = "🗑 %@ removed %@'s message";
 
+"event.edit" = "edited";
+
 "event.context-menu.add-reaction" = "Add Reaction";
 "event.context-menu.reply" = "Reply";
 "event.context-menu.edit" = "Edit";


### PR DESCRIPTION
This Fixes #4 and changes the fact that messages are shown as new messages and adds an edited tag to it, so it is visible that messages are edited.

I am new to swift and new to this project, so let me know if this is how I should have done this. Maybe there is an easier/better way to do this :D