### PR TITLE
Added edit functionality

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		39C9320B23856033004449E1 /* MessageComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C9320A23856033004449E1 /* MessageComposerView.swift */; };
 		39D166C62385C804006DD257 /* String+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D166C52385C804006DD257 /* String+Emoji.swift */; };
 		39D166C82385C832006DD257 /* EventContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D166C72385C832006DD257 /* EventContainerView.swift */; };
+		4B058B5624573A570059BC75 /* EditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B058B5524573A570059BC75 /* EditEvent.swift */; };
 		87FE3870173FD55A91B15921 /* Pods_Nio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3410F361E5A713D19ECEF861 /* Pods_Nio.framework */; };
 		A329A2AF0574896611D82CC1 /* Pods_NioTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FF7D25C200D0F7228279B72 /* Pods_NioTests.framework */; };
 		CAC46D5723A272D10079C24F /* BorderlessMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC46D5423A272D10079C24F /* BorderlessMessageView.swift */; };
@@ -152,6 +153,7 @@
 		39C9320A23856033004449E1 /* MessageComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerView.swift; sourceTree = "<group>"; };
 		39D166C52385C804006DD257 /* String+Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Emoji.swift"; sourceTree = "<group>"; };
 		39D166C72385C832006DD257 /* EventContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventContainerView.swift; sourceTree = "<group>"; };
+		4B058B5524573A570059BC75 /* EditEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEvent.swift; sourceTree = "<group>"; };
 		7FF7D25C200D0F7228279B72 /* Pods_NioTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NioTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAC46D5423A272D10079C24F /* BorderlessMessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderlessMessageView.swift; sourceTree = "<group>"; };
 		CAC46D5523A272D10079C24F /* MessageViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageViewModel.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 			isa = PBXGroup;
 			children = (
 				39222198243689D6004D8794 /* ReactionEvent.swift */,
+				4B058B5524573A570059BC75 /* EditEvent.swift */,
 				3922219C24368B25004D8794 /* CustomEvent.swift */,
 			);
 			path = "Custom Events";
@@ -702,6 +705,7 @@
 				392389892386FD3900B2E1DF /* MXClient+Publisher.swift in Sources */,
 				3984654523B7ECBA006C173B /* MXURL.swift in Sources */,
 				392389D2238F2E6F00B2E1DF /* NIORoom.swift in Sources */,
+				4B058B5624573A570059BC75 /* EditEvent.swift in Sources */,
 				392221AE243A0508004D8794 /* GroupedReactionsView.swift in Sources */,
 				3923898F2388707E00B2E1DF /* RoomListItemView.swift in Sources */,
 				39C931DD2384328A004449E1 /* AppDelegate.swift in Sources */,

--- a/Nio/Conversations/ContextMenu/EventContextMenu.swift
+++ b/Nio/Conversations/ContextMenu/EventContextMenu.swift
@@ -28,7 +28,7 @@ private struct EventContextMenuViewModel {
         if event.sender == userId
             && reactableEvents.contains(event.type)
             && !event.isRedactedEvent() {
-//            canEdit = true
+            canEdit = true
             canRedact = true
         }
 

--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -42,7 +42,7 @@ struct EventContainerView: View {
             if event.contentHasBeenEdited() {
                 newEvent = edits.last ?? event
             }
-            
+
             // FIXME: remove
             // swiftlint:disable:next force_try
             let messageModel = try! MessageViewModel(event: newEvent,

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -61,9 +61,7 @@ struct RoomView: View {
     var onRedact: (String, String?) -> Void
     var onEdit: (String, String) -> Void
 
-    @State private var edited = false
-    @State private var editEventId = ""
-
+    @State private var editEventId: String?
     @State private var eventToRedact: String?
 
     @State private var message = ""
@@ -103,21 +101,19 @@ struct RoomView: View {
     }
 
     private func send() {
-        if !edited {
+        if editEventId == nil {
             onCommit(message)
             message = ""
         } else {
-            onEdit(message, editEventId)
+            onEdit(message, editEventId!)
             message = ""
-            editEventId = ""
-            edited = false
+            editEventId = nil
         }
     }
 
     private func edit(event: MXEvent) {
         message = event.content["body"] as? String ?? ""
         editEventId = event.eventId
-        edited = true
     }
 }
 

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -22,6 +22,9 @@ struct RoomContainerView: View {
             },
             onRedact: { eventId, reason in
                 self.room.redact(eventId: eventId, reason: reason)
+            },
+            onEdit: { message, eventId in
+                self.room.edit(text: message, eventId: eventId)
             }
         )
         .navigationBarTitle(Text(room.summary.displayname ?? ""), displayMode: .inline)
@@ -56,6 +59,11 @@ struct RoomView: View {
 
     var onReact: (String) -> Void
     var onRedact: (String, String?) -> Void
+    var onEdit: (String, String) -> Void
+
+    @State private var edited = false
+    @State private var editEventId = ""
+
     @State private var eventToRedact: String?
 
     @State private var message = ""
@@ -73,7 +81,7 @@ struct RoomView: View {
                                     userId: self.userId,
                                     onReact: { self.onReact(event.eventId) },
                                     onReply: { },
-                                    onEdit: { },
+                                    onEdit: { self.edit(event: event) },
                                     onRedact: { self.eventToRedact = event.eventId }))
                     .padding(.horizontal)
             }
@@ -95,8 +103,21 @@ struct RoomView: View {
     }
 
     private func send() {
-        onCommit(message)
-        message = ""
+        if !edited {
+            onCommit(message)
+            message = ""
+        } else {
+            onEdit(message, editEventId)
+            message = ""
+            editEventId = ""
+            edited = false
+        }
+    }
+
+    private func edit(event: MXEvent) {
+        message = event.content["body"] as? String ?? ""
+        editEventId = event.eventId
+        edited = true
     }
 }
 

--- a/Nio/Matrix Wrapper/Custom Events/EditEvent.swift
+++ b/Nio/Matrix Wrapper/Custom Events/EditEvent.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftMatrixSDK
+
+struct EditEvent {
+    let eventId: String
+    let text: String
+}
+
+extension EditEvent: CustomEvent {
+    func encodeContent() throws -> [String: Any] {
+        [
+            "body": "*" + text,
+            "m.new_content": [
+                "body": text,
+                "msgtype": kMXMessageTypeText
+            ],
+            "m.relates_to": [
+                "event_id": eventId,
+                "rel_type": MXEventRelationTypeReplace
+            ],
+            "msgtype": kMXMessageTypeText
+        ]
+    }
+}

--- a/Nio/Matrix Wrapper/NIORoom.swift
+++ b/Nio/Matrix Wrapper/NIORoom.swift
@@ -80,20 +80,10 @@ class NIORoom: ObservableObject {
         guard !text.isEmpty else { return }
         //swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
-        let messageObject: [String: Any] = [
-            "body": "*" + text,
-            "m.new_content": [
-                "body": text,
-                "msgtype": "m.text"
-            ],
-            "m.relates_to": [
-                "event_id": eventId,
-                "rel_type": "m.replace"
-            ],
-            "msgtype": "m.text"
-        ]
+        // swiftlint:disable:next force_try
+        let content = try! EditEvent(eventId: eventId, text: text).encodeContent()
         // TODO: Use localEcho to show sent message until it actually comes back
-        room.sendMessage(withContent: messageObject, localEcho: &localEcho) { _ in
+        room.sendMessage(withContent: content, localEcho: &localEcho) { _ in
             self.objectWillChange.send()
         }
         self.objectWillChange.send()

--- a/Nio/Matrix Wrapper/NIORoom.swift
+++ b/Nio/Matrix Wrapper/NIORoom.swift
@@ -60,8 +60,7 @@ class NIORoom: ObservableObject {
         //swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
         // TODO: Use localEcho to show sent message until it actually comes back
-        room.sendTextMessage(text, localEcho: &localEcho) { response in
-            print(response)
+        room.sendTextMessage(text, localEcho: &localEcho) { _ in
             self.objectWillChange.send()
         }
         self.objectWillChange.send()
@@ -72,8 +71,7 @@ class NIORoom: ObservableObject {
         let content = try! ReactionEvent(eventId: eventId, key: emoji).encodeContent()
         //swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
-        room.sendEvent(.reaction, content: content, localEcho: &localEcho) { response in
-            print(response)
+        room.sendEvent(.reaction, content: content, localEcho: &localEcho) { _ in
             self.objectWillChange.send()
         }
     }
@@ -95,8 +93,7 @@ class NIORoom: ObservableObject {
             "msgtype": "m.text"
         ]
         // TODO: Use localEcho to show sent message until it actually comes back
-        room.sendMessage(withContent: messageObject, localEcho: &localEcho) { response in
-            print(response)
+        room.sendMessage(withContent: messageObject, localEcho: &localEcho) { _ in
             self.objectWillChange.send()
         }
         self.objectWillChange.send()

--- a/Nio/Matrix Wrapper/NIORoom.swift
+++ b/Nio/Matrix Wrapper/NIORoom.swift
@@ -78,6 +78,30 @@ class NIORoom: ObservableObject {
         }
     }
 
+    func edit(text: String, eventId: String) {
+        guard !text.isEmpty else { return }
+        //swiftlint:disable:next redundant_optional_initialization
+        var localEcho: MXEvent? = nil
+        let messageObject: [String: Any] = [
+            "body": "*" + text,
+            "m.new_content": [
+                "body": text,
+                "msgtype": "m.text"
+            ],
+            "m.relates_to": [
+                "event_id": eventId,
+                "rel_type": "m.replace"
+            ],
+            "msgtype": "m.text"
+        ]
+        // TODO: Use localEcho to show sent message until it actually comes back
+        room.sendMessage(withContent: messageObject, localEcho: &localEcho) { response in
+            print(response)
+            self.objectWillChange.send()
+        }
+        self.objectWillChange.send()
+    }
+
     func redact(eventId: String, reason: String?) {
         room.redactEvent(eventId, reason: reason) { response in
             self.objectWillChange.send()


### PR DESCRIPTION
This is part of #53, while long-pressing a message and edit option will appear and you will then be able to edit the message.

I am not sure if this is the way to send an edit, but I couldn't find a better way to do it.
```Swift
func edit(text: String, eventId: String) {
        guard !text.isEmpty else { return }
        //swiftlint:disable:next redundant_optional_initialization
        var localEcho: MXEvent? = nil
        let messageObject: [String: Any] = [
            "body": "*" + text,
            "m.new_content": [
                "body": text,
                "msgtype": "m.text"
            ],
            "m.relates_to": [
                "event_id": eventId,
                "rel_type": "m.replace"
            ],
            "msgtype": "m.text"
        ]
        // TODO: Use localEcho to show sent message until it actually comes back
        room.sendMessage(withContent: messageObject, localEcho: &localEcho) { response in
            print(response)
            self.objectWillChange.send()
        }
        self.objectWillChange.send()
    }
```